### PR TITLE
Deploy Elasticsearch/Kibana to example Minikube instance

### DIFF
--- a/examples/minikube/es-cluster.tf
+++ b/examples/minikube/es-cluster.tf
@@ -1,0 +1,25 @@
+module "elastic-cluster"{
+  source = "../../modules/elastic-cluster"
+
+  namespace = "default"
+  values-file = "examples/minikube/es-cluster.values.yaml"
+
+  es-name = "cluster"
+  kibana-name = "siem"
+}
+
+output "elastic-cluster-user-secret" {
+  value = module.elastic-cluster.es-user-secret
+}
+
+output "elastic-cluster-tls-secret" {
+  value = module.elastic-cluster.es-certs
+}
+
+output "elasticsearch-svc-url" {
+  value = module.elastic-cluster.es-url-internal
+}
+
+output "kibana-svc-url" {
+  value = module.elastic-cluster.kb-url-internal
+}

--- a/examples/minikube/es-cluster.values.yaml
+++ b/examples/minikube/es-cluster.values.yaml
@@ -1,0 +1,39 @@
+# ----
+elasticsearch:
+  name: ""
+  version: 7.9.0
+  nodeSets:
+    - name: nset1
+      count: 1
+      mmap:
+        vm_max_map_count: 262144
+        enabled: false
+      roles:
+        - "master"
+        - "data"
+        - "ingest"
+      limits:
+        cpu: 0.9
+        memory: 2Gi
+      heapSize: 1700m  # Use [m for Megabytes, g for gigabytes]
+      volumeClaims:
+        enabled: true
+        class: standard
+        size: 512Mi
+  service:
+    enabled: true
+    type: ClusterIP
+    # name: elastisearch
+# ----
+kibana:
+  name: ""
+  version: 7.9.0
+  # To increase "count" - 'xpack.encryptedSavedObjects.encryptionKey' needs to be set
+  count: 1
+  encryptionKey:
+    enabled: True
+    # 'xpack.encryptedSavedObjects.encryptionKey' value:
+    value: "" # If blank, a random key will be generated
+  limits:
+    cpu: 0.5
+    memory: 1Gi

--- a/examples/minikube/provider.tf
+++ b/examples/minikube/provider.tf
@@ -1,0 +1,7 @@
+provider "helm" {
+  version = "~> 1.3"
+
+  kubernetes {
+    config_context = "minikube"
+  }
+}


### PR DESCRIPTION
This commit uses the TF module and Helm chart to deploy Elastic stack on
a Minikube kubernetes environment.

The `examples/minikube/es-cluster.values.yaml` file contains values
compatible with the scale of a Minikube single node K8s instance. 