### PR TITLE
Fluentd docker for Mongo native plugin

### DIFF
--- a/dockerfiles/fluentd-elasticsearch-mongo/Dockerfile
+++ b/dockerfiles/fluentd-elasticsearch-mongo/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcr.io/google-containers/fluentd-elasticsearch:v2.4.0 AS builder
+
+RUN apt update -y && \
+	apt install gcc make ruby2.3-dev -y \
+	&& gem install fluent-plugin-mongo
+
+FROM gcr.io/google-containers/fluentd-elasticsearch:v2.4.0 AS image
+
+COPY --from=builder /var/lib/gems/ /var/lib/gems/
+COPY --from=builder /usr/lib/ruby/2.3.0/ /usr/lib/ruby/2.3.0/
+
+ENTRYPOINT /run.sh


### PR DESCRIPTION
This PR adds a custom Dockerfile based on
`gcr.io/google-containers/fluentd-elasticsearch` that does natively
support `https://github.com/fluent/fluent-plugin-mongo`.

The plugin could not be installed through the Helm chart as it
needs native build, which is not supported in the existing docker image.

An issue has been already filed under the plugin's Github page [1]
and the Docker file is available for pulling at DockerHub [2] [3]

[1] :https://github.com/fluent/fluent-plugin-mongo/issues/149
[2] :https://hub.docker.com/r/operatorequals/fluentd-elasticsearch
[3] :`docker pull operatorequals/fluentd-elasticsearch:v2.4.0-mongo`