### PR TITLE
Ingester ES Host TF module [FIX]

### DIFF
--- a/modules/ingester/helm.tf
+++ b/modules/ingester/helm.tf
@@ -76,7 +76,7 @@ resource "helm_release" "fluentd-in" {
   }
 
   set {
-    name  = "extraEnvVars[0].value"
+    name  = "output.host"
     value = var.es_host
   }
   set {


### PR DESCRIPTION
This commit fixes a typo in `modules/ingester/helm.tf`
that didn't set the `host.output` of the `values.yaml`.