### PR TITLE
[HOTFIX] Praeco TF module dependency

### DIFF
--- a/examples/minikube/praeco.tf
+++ b/examples/minikube/praeco.tf
@@ -9,5 +9,7 @@ module "praeco"{
   es_username = "elastic"
   es_credentials_k8s_secret = module.elastic-cluster.es-user-secret
   es_tls_k8s_secret = module.elastic-cluster.es-certs
+
+  depends_on = [module.elastic-cluster]
 }
 

--- a/modules/praeco/helm.tf
+++ b/modules/praeco/helm.tf
@@ -36,5 +36,5 @@ resource "helm_release" "praeco" {
     value = data.kubernetes_secret.es_credentials_k8s_secret.data["${var.es_username}"]
   }
 
-
+  depends_on = [data.kubernetes_secret.es_credentials_k8s_secret]
 }


### PR DESCRIPTION
Praeco TF module does depend on ES cluster K8s secrets to
get deployed. This is impossible to do in Terraform 0.12.

The `depends_on` is set to `praeco` module, bumping the
compatible TF version to 0.13.x .