### PR TITLE
Enable  Helm switch for Praeco TF Module

### DIFF
--- a/modules/praeco/helm.tf
+++ b/modules/praeco/helm.tf
@@ -6,6 +6,7 @@ resource "helm_release" "praeco" {
   # version   = "9.3.0"
   create_namespace = true
   dependency_update = true  # To use the `elastalert-server` Helm Chart
+  recreate_pods = true
   
   values = [
     file("${path.module}/../../${var.values-file}")


### PR DESCRIPTION
This PR sets `recreate_pods` Helm switch to `true` in Praeco TF module `modules/praeco/helm.tf`.

This way it is ensured that ConfigMaps and Secrets are remounted
and configuration changes are applied, when re-applying the TF Module.

For example when changing the Slack Web-Hook url the baserule_config secret was updated,
yet the elastalert-server pod was not automatically restarted and kept its previous configuration.