### PR TITLE
ECK operator helm chart terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,7 @@ The name and the artwork are based on [byt3bl33d3rs' *Red-Baron*](https://github
 
 **Blue Baron works with Terraform version 0.13.x or newer.** 
 
-### Elastic on Cloud Kubernetes (ECK) - Operator
-ECK operator is the first step to set up Blue Baron infrastructure.
-It is common to all providers, from managed cloud K8s clusters to bare-metal clusters and `minikube`.
-
-### ECK Installation
-
-Install ECK, either with `all-in-one.yaml` (https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-eck.html):
-```bash
-kubectl apply -f https://download.elastic.co/downloads/eck/1.2.1/all-in-one.yaml
-```
-or by downloading the Helm Chart:
-```bash
-git clone https://github.com/elastic/cloud-on-k8s/
-helm install elastic-operator cloud-on-k8s/deploy/eck-operator -n elastic-system --create-namespace 
-```
-
-*After installing ECK*, navigate under `examples/` for instructions on deploying Blue-Baron environments on:
+Navigate under `examples/` for instructions on deploying Blue-Baron environments on:
 * [Bare-Metal](https://github.com/operatorequals/Blue-Baron/tree/main/examples/bare-metal) and [Minimum](https://github.com/operatorequals/Blue-Baron/tree/main/examples/bare-metal-minimum)
 * AWS ([TBD](https://github.com/operatorequals/Blue-Baron/projects/1))
 * Azure ([TBD](https://github.com/operatorequals/Blue-Baron/projects/3))

--- a/examples/bare-metal-minimum/README.md
+++ b/examples/bare-metal-minimum/README.md
@@ -11,7 +11,7 @@ or Production-Ready [K3s](https://github.com/rancher/k3s), [kOps](https://github
 
 ## Setup
 
-After [installing ECK](https://github.com/operatorequals/Blue-Baron#eck-installation) the deployment process goes as below.
+The deployment process consists of Terraform and Helm `values.yaml` configuration.
 
 ### Configure
 

--- a/examples/bare-metal-minimum/eck-operator.tf
+++ b/examples/bare-metal-minimum/eck-operator.tf
@@ -1,0 +1,4 @@
+module "eck-operator" {
+  source = "../../modules/eck-operator"
+
+}

--- a/examples/bare-metal-minimum/es-cluster.tf
+++ b/examples/bare-metal-minimum/es-cluster.tf
@@ -6,6 +6,8 @@ module "elastic-cluster"{
 
   es-name = "cluster"
   kibana-name = "siem"
+
+  depends_on = [module.eck-operator]
 }
 
 output "elastic-cluster-user-secret" {

--- a/examples/bare-metal/README.md
+++ b/examples/bare-metal/README.md
@@ -11,7 +11,7 @@ or Production-Ready [K3s](https://github.com/rancher/k3s), [kOps](https://github
 
 ## Setup
 
-After [installing ECK](https://github.com/operatorequals/Blue-Baron#eck-installation) the deployment process goes as below.
+The deployment process consists of Terraform and Helm `values.yaml` configuration.
 
 ### Configure
 

--- a/examples/bare-metal/eck-operator.tf
+++ b/examples/bare-metal/eck-operator.tf
@@ -1,0 +1,4 @@
+module "eck-operator" {
+  source = "../../modules/eck-operator"
+
+}

--- a/examples/bare-metal/es-cluster.tf
+++ b/examples/bare-metal/es-cluster.tf
@@ -6,6 +6,8 @@ module "elastic-cluster"{
 
   es-name = "cluster"
   kibana-name = "siem"
+
+  depends_on = [module.eck-operator]
 }
 
 output "elastic-cluster-user-secret" {

--- a/modules/eck-operator/helm.tf
+++ b/modules/eck-operator/helm.tf
@@ -1,0 +1,12 @@
+resource "helm_release" "eck-operator" {
+  name              = "eck-operator"
+  chart             = "eck-operator"
+  repository        = "https://helm.elastic.co/"
+  namespace         = var.namespace
+  create_namespace  = true
+
+  set {
+    name = "installCRDs"
+    value = var.crds
+  }
+}

--- a/modules/eck-operator/variables.tf
+++ b/modules/eck-operator/variables.tf
@@ -1,0 +1,7 @@
+variable "namespace" {
+  default = "elastic-system"
+}
+
+variable "crds" {
+  default = true
+}


### PR DESCRIPTION
Updates all examples to deploy a new module that automatically install the ECK operator.

Additionally updates all READMEs, to not contain the manual ECK installation steps.